### PR TITLE
CATID Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,219 @@
+# Created by .ignore support plugin (hsz.mobi)
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+.venv
+pip-selfcheck.json
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*

--- a/sensortools/sensortools.py
+++ b/sensortools/sensortools.py
@@ -585,9 +585,10 @@ class sensortools(object):
         Format the results into a pandas df. To be used in plotting functions
         but also useful outside of them.
         """
-        cat, s, t, c, n, e, f, i, k = [], [], [], [], [], [], [], [], []
+        ids, cat, s, t, c, n, e, f, i, k = [], [], [], [], [], [], [], [], [], []
         for j, re in enumerate(search_results):
-            cat.append(re['identifier'])
+            ids.append(re['identifier'])
+            cat.append(re['properties'].get('catalogID'))
             s.append(re['properties']['sensorPlatformName'])
             t.append(re['properties']['timestamp'])
             # Catches for Landsat and RadarSat images missing these properties
@@ -608,6 +609,7 @@ class sensortools(object):
             k.append(self.aoiArea(re['properties']['footprintWkt']))
 
         df = pd.DataFrame({
+            'image_identifier': ids,
             'catalog_id': cat,
             'Sensor': s,
             'Date': pd.to_datetime(t),


### PR DESCRIPTION
This fixes that issue I was talking to you about yesterday where depending on how the Catalog Search is conducted, the `identifier` in the entry might not actually be the CATID. This adds an additional `image_identifier` field to the dataframe, which holds the `identifier` from the catalog entry, and it populates the `catalog_id` column with the `catalogID` property from the entry. 

You can test with:

```python
from gbdxtools import Interface
from sensortools import sensortools
from datetime import datetime, timedelta

gbdx = Interface()
st = sensortools()

aoi = "POLYGON ((-157.86749900000000935 21.29066178118170072, -157.86749900000000935 21.31490499999999955, -157.85125104361799231 21.31490499999999955, -157.85125104361799231 21.29066178118170072, -157.86749900000000935 21.29066178118170072))"

start_date='2018-01-16T00:00:00.000Z'
end_date='2019-01-16T00:00:00.000Z'

filters = ["(sensorPlatformName = 'WORLDVIEW03_VNIR' OR sensorPlatformName = 'WORLDVIEW04')"]

results = gbdx.catalog.search(
    searchAreaWkt=aoi, 
    startDate=start_date, 
    endDate=end_date, 
    filters=filters, 
    types=['WV03_VNIR']
)
st_results = st.formatSearchResults(results, aoi)

st_results[st_results.image_identifier != st_results.catalog_id].head()
```
